### PR TITLE
Change default McHck swd adapter pins

### DIFF
--- a/bootloader/swd-adapter/swduino/swd.h
+++ b/bootloader/swd-adapter/swduino/swd.h
@@ -36,8 +36,8 @@ enum swd_pin_mode {
 #include <mchck.h>
 
 enum swd_pin {
-	SWD_DIO_PIN = GPIO_PTB16,
-	SWD_CLK_PIN = GPIO_PTB3
+	SWD_DIO_PIN = GPIO_PTA3,
+	SWD_CLK_PIN = GPIO_PTA0
 };
 
 enum swd_pin_mode {


### PR DESCRIPTION
Update default swd adapter pins to use PA0 for SWCLK and PA3 for SWDIO as they are the hardware defaults and will need to be populated for the initial code flash.
