### PR TITLE
Add fflush for manual stdio flushing.

### DIFF
--- a/toolchain/lib/mchck/stdio.c
+++ b/toolchain/lib/mchck/stdio.c
@@ -31,6 +31,29 @@ fputc(int c, FILE *f)
         crit_exit();
 }
 
+int fflush(FILE *f)
+{
+    crit_enter();
+
+    /* number of buffered characters */
+    size_t buffered = f->outbuf_head - f->outbuf_tail;
+    if (buffered < 0)
+            buffered += sizeof(f->outbuf) - 1;
+
+    size_t n;
+    if (f->outbuf_head > f->outbuf_tail) {
+            n = buffered;
+    } else {
+            n = sizeof(f->outbuf) - f->outbuf_tail;
+    }
+    size_t written = f->ops->write(&f->outbuf[f->outbuf_tail],
+                                   n, f->ops_data);
+    f->outbuf_tail = (f->outbuf_tail + written) % sizeof(f->outbuf);
+    crit_exit();
+
+    return 0;
+}
+
 struct buffer_file_ctx {
         char *buf;
         size_t buflen;

--- a/toolchain/lib/mchck/stdio.h
+++ b/toolchain/lib/mchck/stdio.h
@@ -25,3 +25,4 @@ int vfprintf(FILE *f, const char *fmt, va_list args);
 void fputc(int c, FILE *f);
 int snprintf(char *buf, size_t n, const char *fmt, ...) __attribute__((__format__ (printf, 3, 4)));
 int vsnprintf(char *buf, size_t n, const char *fmt, va_list args);
+int fflush(FILE *f);


### PR DESCRIPTION
This is useful if you want to print something like an input prompt without a newline, or any other use cases in which you get short bursts of data without a newline.
