### PR TITLE
lib/adc: mark adc status volatile

### DIFF
--- a/toolchain/lib/mchck/adc.c
+++ b/toolchain/lib/mchck/adc.c
@@ -1,7 +1,7 @@
 #include <mchck.h>
 
 struct adc_ctx {
-        struct {
+        volatile struct {
                 adc_result_cb_t *cb;
                 void *cbdata;
                 int active;


### PR DESCRIPTION
Seems LTO is smart enough to deduce that the status does never
change (because it only does from interrupt context).

Reported-by: stg
