### PR TITLE
Move target sections to directly after .text

### DIFF
--- a/toolchain/ld/link.ld.S
+++ b/toolchain/ld/link.ld.S
@@ -28,6 +28,10 @@ SECTIONS
 /* PACK SECTIONS END */
     } > rom
 
+#ifdef TARGET_SECTIONS_LDSCRIPT
+#include TARGET_SECTIONS_LDSCRIPT
+#endif
+
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
@@ -40,10 +44,6 @@ SECTIONS
 
     . = ALIGN(4);
     _etext = .;
-
-#ifdef TARGET_SECTIONS_LDSCRIPT
-#include TARGET_SECTIONS_LDSCRIPT
-#endif
 
     /* The USB BDT has to be aligned to a 512 byte boundary */
     .usb_bdt (NOLOAD) :


### PR DESCRIPTION
This fixes overlapping section errors during linking.
