### PR TITLE
nrf: Call pin_change_init

### DIFF
--- a/toolchain/lib/nrf/nrf.c
+++ b/toolchain/lib/nrf/nrf.c
@@ -318,7 +318,8 @@ nrf_init(void)
 	gpio_write(NRF_CE, 0);
 
 	gpio_dir(NRF_IRQ, GPIO_INPUT);
-	int_enable(IRQ_PORTC);
+
+	pin_change_init();
 }
 
 void


### PR DESCRIPTION
This was overlooked in 3397b6b4520aeaa4ebfc52f92552662908accf6f.
