### PR TITLE
adc_queue: Add adc_queue_init

### DIFF
--- a/toolchain/lib/mchck/adc_queue.c
+++ b/toolchain/lib/mchck/adc_queue.c
@@ -63,3 +63,10 @@ adc_calibration_done(void)
 {
         adc_busy = false;
 }
+
+void
+adc_queue_init(void)
+{
+        adc_busy = true;
+        adc_init();
+}

--- a/toolchain/lib/mchck/adc_queue.h
+++ b/toolchain/lib/mchck/adc_queue.h
@@ -18,3 +18,6 @@ struct adc_queue_ctx {
 void adc_queue_sample(struct adc_queue_ctx *ctx,
                       enum adc_channel channel, enum adc_mode mode,
                       adc_result_cb_t *cb, void *cbdata);
+
+/* This should be called in lieu of adc_init() */
+void adc_queue_init(void);


### PR DESCRIPTION
This allows one to re-initialize the ADC, ensuring that the queue is
frozen during the process.
