### PR TITLE
Various fixes

### DIFF
--- a/toolchain/include/kinetis/mcg.h
+++ b/toolchain/include/kinetis/mcg.h
@@ -5,7 +5,10 @@ struct MCG_t {
                 UNION_STRUCT_START(8);
                 uint8_t irefsten : 1;
                 uint8_t irclken : 1;
-                uint8_t irefs : 1;
+                enum {
+                        MCG_IREFS_EXTERNAL = 0,
+                        MCG_IREFS_INTERNAL = 1
+                } irefs : 1;
                 uint8_t frdiv : 3;
                 enum {
                         MCG_CLKS_FLLPLL = 0,

--- a/toolchain/lib/mchck/spi.c
+++ b/toolchain/lib/mchck/spi.c
@@ -1,6 +1,6 @@
 #include <mchck.h>
 
-static struct spi_ctx_bare *spi_ctx;
+static struct spi_ctx_bare *volatile spi_ctx;
 
 static void
 spi_start_xfer(void)
@@ -88,7 +88,7 @@ spi_queue_xfer_sg(struct spi_ctx_bare *ctx,
 
         crit_enter();
         /* search for tail and append */
-        for (struct spi_ctx_bare **c = &spi_ctx; ; c = &(*c)->next) {
+        for (struct spi_ctx_bare *volatile *c = &spi_ctx; ; c = &(*c)->next) {
                 if (*c == NULL) {
                         *c = ctx;
                         /* we're at the head, so start xfer */

--- a/toolchain/lib/mchck/spi.c
+++ b/toolchain/lib/mchck/spi.c
@@ -19,7 +19,7 @@ spi_start_xfer(void)
                                 .rfdf_re = spi_ctx->rx != NULL,
                                 .eoqf_re = 1,
                                 }).raw;
-        SPI0.sr.raw |= 0;
+        SPI0.sr.raw |= 0xffffffff;
 }
 
 static void
@@ -35,7 +35,7 @@ spi_stop_xfer(void)
                                 .halt = 1
                                 }).raw;
         SPI0.rser.raw = 0;
-        SPI0.sr.raw |= 0;
+        SPI0.sr.raw |= 0xffffffff;
 }
 
 bool spi_is_idle(void)

--- a/toolchain/lib/usb/cdc-acm.c
+++ b/toolchain/lib/usb/cdc-acm.c
@@ -83,8 +83,49 @@ cdc_write_string(const char *s, struct cdc_ctx *ctx)
  * 0x21, 0x32
  */
 
+static void
+cdc_handle_control_set_line_coding(void *buf, ssize_t len, void *cbdata)
+{
+        usb_handle_control_status(0);
+}
+
+/* Windows 7 fails to configure device unless this is implemented */
+static int
+cdc_handle_control(struct usb_ctrl_req_t *req, void *data)
+{
+        struct cdc_ctx *ctx = data;
+        switch ((enum cdc_ctrl_req_code)req->bRequest) {
+        case USB_CTRL_REQ_CDC_SET_LINE_CODING: {
+                if (req->wLength != sizeof(struct cdc_line_coding)) {
+                        usb_handle_control_status(1);
+                } else {
+                        usb_ep0_rx(&ctx->line_coding, req->wLength, cdc_handle_control_set_line_coding, ctx);
+                        return 1;
+                }
+                break;
+        }
+        case USB_CTRL_REQ_CDC_GET_LINE_CODING: {
+                usb_ep0_tx_cp(&ctx->line_coding, sizeof(struct cdc_line_coding), req->wLength, NULL, NULL);
+                usb_handle_control_status(0);
+                break;
+        }
+        case USB_CTRL_REQ_CDC_SET_CTRL_LINE_STATE: {
+                /*
+                 * We should remain inactive unless there is a terminal on the other end of the link,
+                 * indicated by the first two bits of wValue
+                 */
+                ctx->control_lines = req->wValue;
+                usb_handle_control_status(0);
+                break;
+        }
+        default:
+                return 0;
+        }
+        return 0;
+}
 
 const struct usbd_function cdc_function = {
+        .control = cdc_handle_control,
         .interface_count = USB_FUNCTION_CDC_IFACE_COUNT,
 };
 

--- a/toolchain/lib/usb/cdc-acm.c
+++ b/toolchain/lib/usb/cdc-acm.c
@@ -137,8 +137,8 @@ cdc_init(void (*data_ready_cb)(uint8_t *, size_t), void (*data_sent_cb)(size_t),
         ctx->data_sent_cb = data_sent_cb;
         ctx->out_queued = 0;
         ctx->notice_pipe = usb_init_ep(&ctx->header, CDC_NOTICE_EP, USB_EP_TX, CDC_NOTICE_SIZE);
-	ctx->tx_pipe = usb_init_ep(&ctx->header, CDC_TX_EP, USB_EP_TX, CDC_TX_SIZE);
-	ctx->rx_pipe = usb_init_ep(&ctx->header, CDC_RX_EP, USB_EP_RX, CDC_RX_SIZE);
+        ctx->tx_pipe = usb_init_ep(&ctx->header, CDC_TX_EP, USB_EP_TX, CDC_TX_SIZE);
+        ctx->rx_pipe = usb_init_ep(&ctx->header, CDC_RX_EP, USB_EP_RX, CDC_RX_SIZE);
         cdc_read_more(ctx);
         cdc_tx_done(ctx->outbuf, -1, ctx);
 }

--- a/toolchain/lib/usb/cdc-acm.h
+++ b/toolchain/lib/usb/cdc-acm.h
@@ -10,6 +10,23 @@
 #define CDC_RX_EP	1
 #define CDC_RX_SIZE 32
 
+enum cdc_ctrl_req_code {
+        USB_CTRL_REQ_CDC_SET_LINE_CODING = 0x20,
+        USB_CTRL_REQ_CDC_GET_LINE_CODING = 0x21,
+        USB_CTRL_REQ_CDC_SET_CTRL_LINE_STATE = 0x22,
+        USB_CTRL_REQ_CDC_SET_OPERATION_PARAMS = 0x32,
+        USB_CTRL_REQ_CDC_GET_OPERATION_PARAMS = 0x33,
+        USB_CTRL_REQ_CDC_SET_LINE_PARAMS = 0x34,
+};
+
+struct cdc_line_coding {
+        uint32_t dte_rate;
+        uint8_t char_format;
+        uint8_t parity_type;
+        uint8_t data_bits;
+} __packed;
+CTASSERT_SIZE_BYTE(struct cdc_line_coding, 7);
+
 struct cdc_ctx {
         struct usbd_function_ctx_header header;
         struct usbd_ep_pipe_state_t *notice_pipe;
@@ -22,6 +39,8 @@ struct cdc_ctx {
         int out_queued;
         uint8_t outbuf[CDC_TX_SIZE];
         uint8_t inbuf[CDC_RX_SIZE];
+        uint8_t control_lines;
+        struct cdc_line_coding line_coding;
 };
 
 enum cdc_dev_class {


### PR DESCRIPTION
These are various fixes I've accumulated. The first SPI fix prevents the compiler from performing potentially dangerous optimizations. The second correctly clears the `SR` register. The next implements control requests required by Windows 7 (and possibly later, maybe earlier). The last is a style fix.